### PR TITLE
Improve sandbox iframe support and security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
-      if: matrix.node-version == '16.x'
+      if: matrix.node-version == '22.x'
       with:
         name: build-artifacts
         path: |
@@ -54,7 +54,7 @@ jobs:
 
     - name: Upload documentation
       uses: actions/upload-artifact@v4
-      if: matrix.node-version == '16.x'
+      if: matrix.node-version == '22.x'
       with:
         name: documentation
         path: docs/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Glue.embed('./hello-world.html', document.body, {
 	features: {
 		/* Exposed features for the embedded app - yes it goes both ways */
 	},
-	sandboxRestrictions: 'allow-scripts allow-same-origin allow-modals',
+	sandboxRestrictions: 'allow-scripts allow-modals',
 }).then(glue => {
 	/* Resolved when the Glue application is ready */
 	if ('helloWorld' in glue.api) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,8 @@ async function embed(url: string, container: Element, options?: IEmbeddOptions):
 		// Add default option values and ensure options.
 		options = {
 			timeout: 5000,
-			sandboxRestrictions: 'allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-same-origin',
-			featurePolicy: 'animations; autoplay; camera; encrypted-media; fullscreen; geolocation; microphone; speaker; vr',
+			sandboxRestrictions: 'allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts',
+			featurePolicy: 'autoplay; camera; encrypted-media; fullscreen; geolocation; microphone',
 			...options,
 		}
 
@@ -203,7 +203,7 @@ async function embed(url: string, container: Element, options?: IEmbeddOptions):
 
 		// Prepare URL and set it to element.
 		setGlueParameter(src, 'mode', mode);
-		if (origin !== window.origin) {
+		if (origin !== window.origin || options.sandboxRestrictions) {
 			// Cross origin, add glue origin hash parameter to allow white list
 			// checks on the other end.
 			setGlueParameter(src, 'origin', window.origin);


### PR DESCRIPTION
Enhance support for sandboxed iframes by properly handling the 'null' origin that browsers assign to sandboxed contexts. This allows Glue to work with stricter sandbox restrictions while maintaining security.

The implementation now accepts 'null' origins from sandboxed iframes after validating the source window, and switches to wildcard origin ('*') for postMessage in sandbox contexts. Default sandbox restrictions have been updated to remove 'allow-same-origin' for better security, and feature policy defaults no longer include deprecated features. Origin parameters are now added to cross-origin and sandboxed iframe URLs.

Security is maintained by validating the source window before accepting null origins, ensuring messages only come from the expected iframe.